### PR TITLE
Add CSS build workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Build and deploy
+
+on:
+    push:
+        branches: [main]
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Prepare environment
+              uses: actions/setup-node@v2
+              with:
+                  node-version: "16"
+
+            - run: npm i -g sass
+
+            - name: Build
+              run: |
+                mkdir .build
+                sass Main.scss .build/Main.css --no-source-map
+                cp manifest.json powercord_manifest.json cumcord_theme.json LICENSE .build
+                rm -rf *
+                mv .build/* .
+                rmdir .build
+
+            - name: Commit changes
+              run: |
+                  git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git config --local user.name "github-actions[bot]"
+                  git add .
+                  git commit -am "[CI CHORE] Build theme"
+
+            - name: Push to dist branch
+              uses: ad-m/github-push-action@master
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: "dist"
+                  force: true


### PR DESCRIPTION
Adds an automatic sass compilation on any push to `main`, as required by Cumcord. This workflow could be expanded upon to add a BD compatible metadata header quite trivially, but doesn't in its current state.

**IMPORTANT** this workflow needs Github Actions to have write access to your repo, to enable see these steps:
![image](https://user-images.githubusercontent.com/19270622/167267267-9f3bb755-52c2-4529-8a33-9047ec8f5a00.png)
![image](https://user-images.githubusercontent.com/19270622/167267275-f1febb4b-2808-42e3-bc56-b4cc423ba873.png)
![image](https://user-images.githubusercontent.com/19270622/167267283-1695dc1d-dfe8-4c3d-960e-48bff847028e.png)
